### PR TITLE
fix: Remove trailing whitespace character when exporting My List - Closes #4

### DIFF
--- a/chrome/content_scripts/creators/my-list-creator.js
+++ b/chrome/content_scripts/creators/my-list-creator.js
@@ -3,7 +3,7 @@ const myListCreator = () => {
   
   document
     .querySelectorAll('.slider-refocus')
-    .forEach(name => name.getAttribute('aria-label') !== null ? list += `${name.getAttribute('aria-label')} \n` : '')
+    .forEach(name => name.getAttribute('aria-label') !== null ? list += `${name.getAttribute('aria-label')}\n` : '')
  
   return list  
 }

--- a/firefox/content_scripts/creators/my-list-creator.js
+++ b/firefox/content_scripts/creators/my-list-creator.js
@@ -3,7 +3,7 @@ const myListCreator = () => {
 
   document
     .querySelectorAll('.slider-refocus')
-    .forEach(name => name.getAttribute('aria-label') !== null ? list += `${name.getAttribute('aria-label')} \n` : '')
+    .forEach(name => name.getAttribute('aria-label') !== null ? list += `${name.getAttribute('aria-label')}\n` : '')
  
   return list  
 }


### PR DESCRIPTION
Hi, this commit should fix issue #4. The trailing spaces should be removed from the exported list. Please let me know if there is anything I can improve, thank you.